### PR TITLE
avoid es6

### DIFF
--- a/core/transport.js
+++ b/core/transport.js
@@ -94,7 +94,7 @@ module.exports = function (driver) {
 
   function setMu (muInstance) {
     mu = muInstance
-    logger = mu.log.child({ muid })
+    logger = mu.log.child({muid: muid})
   }
 
 
@@ -102,7 +102,7 @@ module.exports = function (driver) {
   function setId (id) {
     muid = id
     if (mu) {
-      logger = mu.log.child({ muid })
+      logger = mu.log.child({muid: muid})
     }
   }
 


### PR DESCRIPTION
@mcollina - should have covered this in the log pr - we should stay away from any es6 stuff (avoid all transpilation for browser - IE11 still has around 15% market share)