### PR TITLE
rm crypto to save 500kb from browser payload

### DIFF
--- a/core/core.js
+++ b/core/core.js
@@ -16,7 +16,6 @@
 
 var assert = require('assert')
 var uuid = require('uuid')
-var crypto = require('crypto')
 var pino = require('pino')
 var errors = require('./err')
 var createRouter = require('./router')
@@ -64,22 +63,19 @@ function createMu (options) {
   }
 
   function dispatch (message, cb) {
-    var hash
-    var digest
+    var id = uuid()
 
     assert(message, 'dispatch requires a valid message')
-    assert(cb && (typeof cb === 'function'), 'dispatch requries a valid callback handler')
+    assert(typeof cb === 'function', 'dispatch requries a valid callback handler')
     logger.debug('dispatching message: ' + message)
 
     if (!(message.pattern || message.response)) {
-      hash = crypto.createHash('sha256')
-      hash.update('' + cb)
-      digest = hash.digest('hex')
-      router.addRoute(null, {muid: digest, tf: cb, type: 'callback'})
-      router.route({pattern: message, protocol: {path: [digest], trace: [digest], ttl: DEFAULT_TTL}}, cb)
-    } else {
-      router.route(message, cb)
+      router.addRoute(null, {muid: id, tf: cb, type: 'callback'})
+      router.route({pattern: message, protocol: {path: [id], trace: [id], ttl: DEFAULT_TTL}}, cb)
+      return
     }
+
+    router.route(message, cb)
   }
 }
 

--- a/test/core/basic.test.js
+++ b/test/core/basic.test.js
@@ -65,3 +65,27 @@ test('route print test', function (t) {
   t.notEqual(routing.indexOf('{"role":"test","cmd":"two"}'), -1)
 })
 
+test('multi-dispatch same cb', function (t) {
+  t.plan(18)
+
+  var mu = createMu({ logLevel: createMu.log.levelInfo })
+  var count = 0
+  var total = 0
+  mu.define({role: 'test', cmd: 'one'}, function (args, cb) {
+    cb(null, {count: ++count, id: args.pattern.id})
+  })
+
+  function handler (err, result) {
+    t.equal(null, err, 'check err is null')
+    t.equal(result.count, ++total, 'check count is ' + total)
+    t.equal(result.count, result.id, 'check count is ' + result.id)
+  }
+
+  mu.dispatch({role: 'test', cmd: 'one', id: 1}, handler)
+  mu.dispatch({role: 'test', cmd: 'one', id: 2}, handler)
+  mu.dispatch({role: 'test', cmd: 'one', id: 3}, handler)
+  mu.dispatch({role: 'test', cmd: 'one', id: 4}, handler)
+  mu.dispatch({role: 'test', cmd: 'one', id: 5}, handler)
+  mu.dispatch({role: 'test', cmd: 'one', id: 6}, handler)
+})
+

--- a/test/core/transport.test.js
+++ b/test/core/transport.test.js
@@ -18,7 +18,7 @@ var test = require('tap').test
 var createMu = require('../../core/core')
 var func = require('../../drivers/func')
 
-test('local handler test', function (t) {
+test('local inbound/outbound test', function (t) {
   t.plan(6)
 
   // service


### PR DESCRIPTION
```sh
$ browserify -r crypto | wc -c
  554305
$ browserify -r md5-o-matic | wc -c
    6545
```
also - using sha256 to generate an ID is heavy handed - md5 should be fine for this case

as an aside - we should maybe review the general approach (sep. issue?)

cc @mcollina 